### PR TITLE
Add AnyJSONEditor to support `[Any]`, `[String: Any]`, etc.

### DIFF
--- a/EditValueView.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/EditValueView.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/SwiftUIColor.git",
       "state" : {
-        "revision" : "61238f7460a04314dc059df68a1aa4c4b7dcb5df",
-        "version" : "0.3.0"
+        "revision" : "aa42f452698cc0f78dcba2c6544f4abf7724602f",
+        "version" : "0.4.0"
       }
     }
   ],

--- a/Example/Example/ContentView.swift
+++ b/Example/Example/ContentView.swift
@@ -83,6 +83,7 @@ struct ContentView: View {
             editValueView(title: "Array", key: "array", keyPath: \.array)
 
             editValueView(title: "Dictionary", key: "dictionary", keyPath: \.dictionary)
+            editValueView(title: "Any Dictionary", key: "anyDictionary", keyPath: \.anyDictionary)
         } header: {
             Text("Collection")
         }
@@ -192,6 +193,7 @@ struct Item {
     var nsuiImage = UIImage(systemName: "swift")
     var cgImage = UIImage(systemName: "swift")?.cgImage
     var ciImage = UIImage(systemName: "swift")?.ciImage
+    var anyDictionary: [String: Any] = ["AA": 0]
 }
 
 struct ACodable: Codable {

--- a/Sources/EditValueView/EditValueView.swift
+++ b/Sources/EditValueView/EditValueView.swift
@@ -286,7 +286,11 @@ public struct EditValueView<Value>: View {
             CodableEditorView($value, key: key, isValidType: $isValidType)
 
         default:
-            notSupportedView
+            if let anyJSONEditor = AnyJSONEditor($value, key: key, isValidType: $isValidType) {
+                anyJSONEditor
+            } else {
+                notSupportedView
+            }
         }
     }
 
@@ -401,6 +405,7 @@ struct Item {
     var nsuiImage = NSUIImage(systemName: "swift")
     var cgImage = NSUIImage(systemName: "swift")?.cgImage
     var ciImage = NSUIImage(systemName: "swift")?.ciImage
+    var anyDictionary: [String: Any] = ["AA": 0]
 #endif
 }
 
@@ -469,6 +474,8 @@ struct EditValueView_Preview: PreviewProvider {
             EditValueView(target, key: "codable", keyPath: \Item.codable)
                 .previewDisplayName("Codable")
 
+            EditValueView(target, key: "anyDictionary", keyPath: \Item.anyDictionary)
+                .previewDisplayName("Any Dictionary")
         }
     }
 }

--- a/Sources/EditValueView/Editors/AnyJSONEditor.swift
+++ b/Sources/EditValueView/Editors/AnyJSONEditor.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import SwiftUIColor
+
+struct AnyJSONEditor<Value>: View {
+    let key: String
+
+    @Binding private var value: Value
+    @Binding private var isValidType: Bool
+
+    @State private var text: String
+
+    init?(_ value: Binding<Value>, key: String, isValidType: Binding<Bool>) {
+        self._value = value
+        self._isValidType = isValidType
+        self.key = key
+
+        guard JSONSerialization.isValidJSONObject(value.wrappedValue),
+              let json = try? JSONSerialization.data(withJSONObject: value.wrappedValue, options: [.prettyPrinted, .sortedKeys]),
+              let jsonString = String(data: json, encoding: .utf8)
+        else {
+            return nil
+        }
+
+        self._text = .init(initialValue: jsonString)
+    }
+
+    var body: some View {
+        VStack {
+            editor
+                .onChange(of: text) { newValue in
+                    textChanged(text: newValue)
+                }
+        }
+    }
+
+    @ViewBuilder
+    var typeDescriptionView: some View {
+        HStack {
+            Text(typeDescription())
+                .font(.system(size: 14, weight: .bold, design: .monospaced))
+                .foregroundColor(.gray)
+            Spacer()
+        }
+        .padding()
+        .background(Color.iOS.secondarySystemFill)
+        .cornerRadius(8)
+    }
+
+    @ViewBuilder
+    var editor: some View {
+        TextEditor(text: $text)
+            .frame(minHeight: 200, maxHeight: .infinity)
+            .border(.black, width: 0.5)
+            .padding(.vertical)
+    }
+
+    func textChanged(text: String) {
+        guard let data = text.data(using: .utf8),
+              let value = try? JSONSerialization.jsonObject(with: data) as? Value
+        else {
+            isValidType = false
+            return
+        }
+        self.value = value
+        isValidType = true
+    }
+
+    func typeDescription() -> String {
+        if let optional = value as? (any OptionalType),
+           optional.wrapped == nil,
+           let type = Value.self as? any DefaultRepresentable.Type {
+            return ValueType.extractType(for: Optional.some(type.defaultValue)).typeName
+        }
+        return ValueType.extractType(for: value).typeName
+    }
+}


### PR DESCRIPTION
現状[Any]や[String: Any]などに対応していなさそうだったので、AnyJSONEditorを追加して対応しました。
